### PR TITLE
hook up travis CI, correct badge, test against updated PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-JMSPaymentCoreBundle [![Build Status](https://secure.travis-ci.org/schmittjoh/JMSPaymentCoreBundle.png?branch=master)](http://travis-ci.org/schmittjoh/JMSPaymentCoreBundle)
+JMSPaymentCoreBundle [![Build Status](https://secure.travis-ci.org/usemarkup/JMSPaymentCoreBundle.png?branch=master)](http://travis-ci.org/usemarkup/JMSPaymentCoreBundle)
 ====================
 
 Documentation: 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -4,7 +4,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // Composer
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {
-    $loader = require_once __DIR__.'/../vendor/autoload.php';
+    $loader = require __DIR__.'/../vendor/autoload.php';
 
     AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 

--- a/composer.json
+++ b/composer.json
@@ -13,25 +13,35 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0",
-        "ext-mcrypt": "*"
+        "ext-mcrypt": "*",
+        "doctrine/orm": "~2.3",
+        "doctrine/dbal": "~2.3",
+        "doctrine/common": "~2.3",
+        "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/config": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0",
+        "symfony/event-dispatcher": "~2.3|~3.0",
+        "symfony/form": "~2.3|~3.0",
+        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/http-foundation": "~2.3|~3.0",
+        "symfony/http-kernel": "~2.3|~3.0",
+        "symfony/validator": "~2.3|~3.0"
     },
     "require-dev": {
-        "symfony/class-loader": "*",
-        "symfony/twig-bundle": "*",
-        "symfony/finder": "*",
+        "phpunit/phpunit": "~4.8|~5.4",
+        "symfony/phpunit-bridge": "~2.7",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0",
+        "symfony/twig-bridge": "~2.3|~3.0",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
         "symfony/form": "*",
         "symfony/validator": "*",
         "symfony/process": "*",
         "symfony/yaml": "*",
-        "sensio/framework-extra-bundle": "*",
-        "doctrine/doctrine-bundle": "*",
-        "doctrine/orm": "*",
-        "jms/payment-paypal-bundle": "*@dev",
-        "jms/aop-bundle": "*",
-        "jms/di-extra-bundle": "*"
+        "sensio/framework-extra-bundle": "~3.0",
+        "doctrine/doctrine-bundle": "~1.6",
+        "jms/payment-paypal-bundle": "*@dev"
     },
     "autoload": {
         "psr-0": { "JMS\\Payment\\CoreBundle": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,4 +16,8 @@
             <directory>./Tests/</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Updates dependency definitions and enables Travis CI testing, making sure we show the correct Travis badge in the README. (It's failing *badly* right now - does nobody run tests?!?!)