### PR TITLE
feat(reapprove): add reapprove transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
 
 before_script:
     - curl -s http://getcomposer.org/installer | php
-    - COMPOSER_ROOT_VERSION=dev-master php composer.phar install --dev
+    - COMPOSER_ROOT_VERSION=dev-master php -d memory_limit=-1 composer.phar install --dev

--- a/Model/FinancialTransactionInterface.php
+++ b/Model/FinancialTransactionInterface.php
@@ -33,6 +33,7 @@ interface FinancialTransactionInterface
     const TRANSACTION_TYPE_REVERSE_APPROVAL = 5;
     const TRANSACTION_TYPE_REVERSE_CREDIT = 6;
     const TRANSACTION_TYPE_REVERSE_DEPOSIT = 7;
+    const TRANSACTION_TYPE_REAPPROVE = 8;
 
     /**
      * @return \JMS\Payment\CoreBundle\Model\CreditInterface|null

--- a/PluginController/PluginController.php
+++ b/PluginController/PluginController.php
@@ -52,7 +52,6 @@ abstract class PluginController implements PluginControllerInterface
     public function __construct(array $options = array(), EventDispatcherInterface $dispatcher = null)
     {
         $this->options = $options;
-
         $this->dispatcher = $dispatcher;
         $this->plugins = array();
     }
@@ -220,7 +219,6 @@ abstract class PluginController implements PluginControllerInterface
             $payment->setState(PaymentInterface::STATE_APPROVING);
             $payment->setApprovingAmount($amount);
             $instruction->setApprovingAmount($instruction->getApprovingAmount() + $amount);
-
             $this->dispatchPaymentStateChange($payment, PaymentInterface::STATE_NEW);
         } else if (PaymentInterface::STATE_APPROVING === $paymentState) {
             if (Number::compare($payment->getTargetAmount(), $amount) !== 0) {
@@ -296,7 +294,6 @@ abstract class PluginController implements PluginControllerInterface
     protected function doReApprove(PaymentInterface $payment, $amount) {
 
         $instruction = $payment->getPaymentInstruction();
-
         if (PaymentInstructionInterface::STATE_VALID !== $instruction->getState()) {
             throw new InvalidPaymentInstructionException('The PaymentInstruction must be in STATE_VALID.');
         }
@@ -313,12 +310,15 @@ abstract class PluginController implements PluginControllerInterface
             }
 
             $plugin = $this->getPlugin($instruction->getPaymentSystemName());
-            $transaction = $payment->getApproveTransaction();
+            $transaction = $this->buildFinancialTransaction();
+            /** @var FinancialTransactionInterface $transaction */
+            $transaction->setPayment($payment->getApproveTransaction()->getPayment());
+            $transaction->setTransactionType(FinancialTransactionInterface::TRANSACTION_TYPE_REAPPROVE);
+            $transaction->setRequestedAmount($payment->getApproveTransaction()->getRequestedAmount());
             $oldState = $payment->getState();
 
             try {
                 $plugin->reApprove($transaction);
-
                 if (PluginInterface::RESPONSE_CODE_SUCCESS === $transaction->getResponseCode()) {
                     $transaction->setState(FinancialTransactionInterface::STATE_SUCCESS);
                     $payment->setState(PaymentInterface::STATE_APPROVED);
@@ -343,26 +343,7 @@ abstract class PluginController implements PluginControllerInterface
                 return $result;
             } catch (PluginBlockedException $blocked) {
                 $transaction->setState(FinancialTransactionInterface::STATE_PENDING);
-
-                if ($blocked instanceof PluginTimeoutException) {
-                    $reasonCode = PluginInterface::REASON_CODE_TIMEOUT;
-                } else if ($blocked instanceof PluginActionRequiredException) {
-
-                    $payment->setState(PaymentInterface::STATE_APPROVING);
-                    $payment->setApprovingAmount($amount);
-                    $instruction->setApprovingAmount($instruction->getApprovingAmount() + $amount);
-                    $instruction->setApprovedAmount(0.0);
-                    $payment->setApprovedAmount(0.0);
-                    $this->dispatchPaymentStateChange($payment, $oldState);
-
-                    $reasonCode = PluginInterface::REASON_CODE_ACTION_REQUIRED;
-                } else if (null === $reasonCode = $transaction->getReasonCode()) {
-                    $reasonCode = PluginInterface::REASON_CODE_BLOCKED;
-                }
-                $transaction->setReasonCode($reasonCode);
-                $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_PENDING);
-
-                $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_PENDING, $reasonCode);
+                $result = $this->buildFinancialTransactionResult($transaction, Result::STATUS_PENDING, $transaction->getResponseCode());
                 $result->setPluginException($blocked);
                 $result->setRecoverable();
 
@@ -379,7 +360,6 @@ abstract class PluginController implements PluginControllerInterface
     protected function doApproveAndDeposit(PaymentInterface $payment, $amount)
     {
         $instruction = $payment->getPaymentInstruction();
-
         if (PaymentInstructionInterface::STATE_VALID !== $instruction->getState()) {
             throw new InvalidPaymentInstructionException('PaymentInstruction\'s state must be VALID.');
         }
@@ -399,16 +379,13 @@ abstract class PluginController implements PluginControllerInterface
             $transaction->setPayment($payment);
             $transaction->setRequestedAmount($amount);
             $payment->addTransaction($transaction);
-
             $payment->setApprovingAmount($amount);
             $payment->setDepositingAmount($amount);
             $payment->setState(PaymentInterface::STATE_APPROVING);
-
             $instruction->setApprovingAmount($instruction->getApprovingAmount() + $amount);
             $instruction->setDepositingAmount($instruction->getDepositingAmount() + $amount);
 
             $this->dispatchPaymentStateChange($payment, $paymentState);
-
             $retry = false;
         } else if (PaymentInterface::STATE_APPROVING === $paymentState) {
             if (0 !== Number::compare($amount, $payment->getApprovingAmount())) {


### PR DESCRIPTION
👢 requested to add the functionality to extend the payment authorization on pre-orders. To do this, we need a reapprove transaction to track the responses on these requests and to also know when the last reapprove request was performed.